### PR TITLE
fix: build: Problem with es2015 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,8 @@
 {
-  "presets": ["es2015", "stage-2"],
+  "presets": [
+    ["es2015", {"modules": false}],
+    "stage-2"
+  ],
   "env": {
     "test": {
       "plugins": [

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015-webpack", "stage-2"],
+  "presets": ["es2015", "stage-2"],
   "env": {
     "test": {
       "plugins": [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "babel": "6.5.2",
-    "babel-core": "6.9.1",
+    "babel-core": "6.13.2",
     "babel-eslint": "6.0.4",
     "babel-loader": "6.2.4",
     "babel-plugin-__coverage__": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "babel-eslint": "6.0.4",
     "babel-loader": "6.2.4",
     "babel-plugin-__coverage__": "11.0.0",
-    "babel-preset-es2015-webpack": "6.4.1",
+    "babel-preset-es2015": "6.13.2",
     "babel-preset-stage-2": "6.5.0",
     "chai": "3.5.0",
     "cpy-cli": "1.0.1",


### PR DESCRIPTION
This PR changes `babel-preset-es2015-webpack` for  `babel-preset-es2015`  

Current issue fixed on PR gajus/babel-preset-es2015-webpack@1c39f8bc558386892963b83a99d95ed6a2c11fdc

More info by @Andarist  

>  [].concat flattens arrays, so concatening an array to an array is like adding elements from the second one to the first one. And they have changed it so the second flat wasnt flattened at all and the list became [a,b,c, [d]] instead of [a,b,c,d]. Therefore filtering in another package babel-preset-es2015-webpack just broke. Im gonna make a pull request to fix it in few minutes.
